### PR TITLE
rename gitpod.yml bash commands

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,7 @@ image:
   file: .gitpod.Dockerfile
 
 tasks:
-  - name: (1) Boot Kurtosis Engine
+  - name: (1) Start Kurtosis Engine
     command: |
       kurtosis engine restart
       clear

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,19 +2,19 @@ image:
   file: .gitpod.Dockerfile
 
 tasks:
-  - name: Restart Kurtosis Engine
+  - name: (1) Boot Kurtosis Engine
     command: |
       kurtosis engine restart
       clear
-  - name: Run Fake Package
+  - name: (2) Initialize workspace
     command: | 
       kurtosis run github.com/fake-package/fake-package-purely-for-analytics || kurtosis clean -a
       clear
-  - name: Open Readme
+  - name: (3) Open Readme
     command: |
       code README.md
       clear
-  - name: Source Autocomplete
+  - name: (4) Install tab-completion
     command: |
       source <(kurtosis completion bash)
       echo "source <(kurtosis completion bash)" >> ~/.bashrc


### PR DESCRIPTION
When opening up the quickstart-gitpod, there are a few tabs on the right that represent the tasks defined in the gitpod.yml file for setting everything up. This PR renames some of those tasks to make it more readable and relevant to the user (so they know what was going on)